### PR TITLE
feat(HttpMessage): add a couple more header checks for client addresses

### DIFF
--- a/src/main/java/io/resurface/messages/HttpMessage.java
+++ b/src/main/java/io/resurface/messages/HttpMessage.java
@@ -119,7 +119,9 @@ public class HttpMessage {
             request_user_agent = value;
         } else if (name.equalsIgnoreCase("cf-connecting-ip") || name.equalsIgnoreCase("fastly-client-ip")
                 || name.equalsIgnoreCase("forwarded") || name.equalsIgnoreCase("forwarded-for")
-                || name.equalsIgnoreCase("true-client-ip") || name.equalsIgnoreCase("x-forwarded-for")) {
+                || name.equalsIgnoreCase("true-client-ip") || name.equalsIgnoreCase("x-forwarded-for")
+                || name.equalsIgnoreCase("x-client-ip") || name.equalsIgnoreCase("x-real-ip")
+                || name.equalsIgnoreCase("x-cluster-client-ip")) {
             request_address = value;
         } else {
             ArrayList<String> list = new ArrayList<>();


### PR DESCRIPTION
This PR adds three additional checks for header keys that might point to a forwarded client address as the corresponding header value, namely: `"x-client-ip"`, `"x-real-ip"`, and `"x-cluster-client-ip"`.