### PR TITLE
Fix: host header

### DIFF
--- a/src/main/java/io/resurface/ndjson/APIConnectMessage.java
+++ b/src/main/java/io/resurface/ndjson/APIConnectMessage.java
@@ -158,6 +158,8 @@ public class APIConnectMessage {
                         gatewayIp = d.get(1); break;
                     case "global_transaction_id":
                         globalTransactionId = d.get(1); break;
+                    case "host":
+                        host = d.get(1); break;
                     case "immediate_client_ip":
                         immediateClientIp = d.get(1); break;
                     case "log_policy":
@@ -214,9 +216,6 @@ public class APIConnectMessage {
             queryString = s.toString();
         }
 
-        // copy host (machine hostname -- unused in 3.6)
-        if (msg.host() != null) host = msg.host();
-
         // copy request url
         if (msg.request_url() != null) {
             try {
@@ -266,6 +265,7 @@ public class APIConnectMessage {
         if (developerOrgTitle != null) msg.add_custom_field("developer_org_title", developerOrgTitle);
         if (gatewayIp != null) msg.add_custom_field("gateway_ip", gatewayIp);
         if (globalTransactionId != null) msg.add_custom_field("global_transaction_id", globalTransactionId);
+        if (host != null) msg.add_custom_field("host", host);
         if (immediateClientIp != null) msg.add_custom_field("immediate_client_ip", immediateClientIp);
         if (logPolicy != null) msg.add_custom_field("log_policy", logPolicy);
         if (orgId != null) msg.add_custom_field("org_id", orgId);
@@ -285,9 +285,6 @@ public class APIConnectMessage {
 
         // copy request body
         if (requestBody != null) msg.set_request_body(requestBody);
-
-        // copy host (machine hostname -- unused in 3.6)
-        if (host != null) msg.set_host(host);
 
         String hostHeader = null;
         // copy request headers

--- a/src/main/java/io/resurface/ndjson/HttpMessage.java
+++ b/src/main/java/io/resurface/ndjson/HttpMessage.java
@@ -42,7 +42,10 @@ public class HttpMessage {
     public void add(String key, String value) {
         switch (key) {
             case "host":
-                host = value;
+                // "host" field has been deprecated since 3.5
+                // request host must be sent as part of request_url
+                // machine host must be sent as a custom_field:host value
+//                host = value;
                 break;
             case "interval":
             case "interval_millis":
@@ -214,7 +217,10 @@ public class HttpMessage {
      * Sets the host that responded to the API call.
      */
     public void set_host(String host) {
-        this.host = host;
+        // "host" field has been deprecated since 3.5
+        // request host must be sent as part of request_url
+        // machine host must be sent as a custom_field:host value
+        //this.host = host;
     }
 
     /**

--- a/src/main/java/io/resurface/ndjson/HttpMessage.java
+++ b/src/main/java/io/resurface/ndjson/HttpMessage.java
@@ -103,6 +103,8 @@ public class HttpMessage {
     public void add_request_header(String name, String value) {
         String name_lower = name.toLowerCase();
         switch (name_lower) {
+            case "host":
+                break;
             case "content-type":
                 request_content_type = value;
                 break;

--- a/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
@@ -45,7 +45,7 @@ public class APIConnectMessageTest {
         // todo additional checks here
 
         // check host
-        expect(m.host()).toBeNull();
+        expect(m.host()).toEqual("172.17.24.166");
 
         // check interval millis
         expect(m.interval_millis()).toEqual(157);
@@ -58,15 +58,13 @@ public class APIConnectMessageTest {
 
         // check request headers
         expect(m.request_content_type()).toEqual("application/json");
-        expect(m.request_headers().size()).toEqual(4);
+        expect(m.request_headers().size()).toEqual(3);
         expect(m.request_headers().get(0).get(0)).toEqual("accept");
         expect(m.request_headers().get(0).get(1)).toEqual("*/*");
         expect(m.request_headers().get(1).get(0)).toEqual("content-length");
         expect(m.request_headers().get(1).get(1)).toEqual("30");
         expect(m.request_headers().get(2).get(0)).toEqual("foo");
         expect(m.request_headers().get(2).get(1)).toEqual("baz");
-        expect(m.request_headers().get(3).get(0)).toEqual("host");
-        expect(m.request_headers().get(3).get(1)).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc-cluster-56665e2c7fa43d098323a9b3845292d3-0000.us-south.containers.appdomain.cloud");
         expect(m.request_user_agent()).toEqual("curl/7.81.0");
 
         // check request method
@@ -78,7 +76,7 @@ public class APIConnectMessageTest {
         expect(m.request_params().get(0).get(1)).toEqual("course");
 
         // check request url
-        expect(m.request_url()).toEqual("https://172.17.24.166/resurface/sandbox/post");
+        expect(m.request_url()).toEqual("https://apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud/resurface/sandbox/post");
 
         // check response body
         expect(m.response_body()).toEqual("{\"data\":\"This is some MORE data!!\"}");
@@ -127,9 +125,9 @@ public class APIConnectMessageTest {
         expect(m.requestHttpHeaders.get(0).get("accept")).toEqual("*/*");
         expect(m.requestHttpHeaders.get(1).get("content-length")).toEqual("30");
         expect(m.requestHttpHeaders.get(2).get("foo")).toEqual("baz");
-        expect(m.requestHttpHeaders.get(3).get("host")).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc-cluster-56665e2c7fa43d098323a9b3845292d3-0000.us-south.containers.appdomain.cloud");
-        expect(m.requestHttpHeaders.get(4).get("content-type")).toEqual("application/json");
-        expect(m.requestHttpHeaders.get(5).get("user-agent")).toEqual("curl/7.81.0");
+        expect(m.requestHttpHeaders.get(3).get("content-type")).toEqual("application/json");
+        expect(m.requestHttpHeaders.get(4).get("user-agent")).toEqual("curl/7.81.0");
+        expect(m.requestHttpHeaders.get(5).get("host")).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud");
 
         // check request method
         expect(m.method).toEqual("POST");

--- a/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
@@ -41,11 +41,11 @@ public class APIConnectMessageTest {
         m.sort_details();
 
         // check custom fields
-        expect(m.custom_fields().size()).toEqual(22);
+        expect(m.custom_fields().size()).toEqual(23);
         // todo additional checks here
 
         // check host
-        expect(m.host()).toEqual("172.17.24.166");
+        expect(m.host()).toBeNull();
 
         // check interval millis
         expect(m.interval_millis()).toEqual(157);

--- a/src/test/java/io/resurface/ndjson/tests/Helper.java
+++ b/src/test/java/io/resurface/ndjson/tests/Helper.java
@@ -20,7 +20,7 @@ public class Helper {
               "global_transaction_id": "58665d8063a1e26c000099d0",
               "request_http_headers": [
                 {
-                  "Host": "apis-minimum-gw-gateway-cp4i.b-vpc-cluster-56665e2c7fa43d098323a9b3845292d3-0000.us-south.containers.appdomain.cloud"
+                  "Host": "apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud"
                 },
                 { "user-agent": "curl/7.81.0" },
                 { "accept": "*/*" },

--- a/src/test/java/io/resurface/ndjson/tests/HttpMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/HttpMessageTest.java
@@ -82,6 +82,7 @@ public class HttpMessageTest {
                 "[\"request_body\", \"{ \\\"hello\\\" : \\\"world\\\" }\"]," +
                 "[\"request_header:a\", \"2\"]," +
                 "[\"request_header:b\", \"1\"]," +
+                "[\"request_header:host\", \"test.pepperin.space\"]," +
                 "[\"request_header:content-type\", \"Application/JSON\"]," +
                 "[\"request_header:user-agent\",\"Mozilla/5.0 (Ubuntu)...\"]," +
                 "[\"request_header:x-forwarded-for\", \"127.0.0.1\"]," +
@@ -103,7 +104,7 @@ public class HttpMessageTest {
         expect(m.custom_fields().size()).toEqual(1);
         expect(m.custom_fields().get(0).get(0)).toEqual("foo");
         expect(m.custom_fields().get(0).get(1)).toEqual("Bar");
-        expect(m.host()).toEqual("radware");
+        expect(m.host()).toBeNull();
         expect(m.interval_millis()).toEqual(292);
         expect(m.request_address()).toEqual("127.0.0.1");
         expect(m.request_body()).toEqual("{ \"hello\" : \"world\" }");
@@ -156,7 +157,11 @@ public class HttpMessageTest {
         m.set_host("radware");
         expect(m.size_request_bytes()).toEqual(0);
         expect(m.size_response_bytes()).toEqual(0);
-        expect(m.toString()).toEqual("[[\"host\",\"radware\"]]");
+        expect(m.toString()).toEqual("[]");
+        m.add_custom_field("host", "radware");
+        expect(m.size_request_bytes()).toEqual(0);
+        expect(m.size_response_bytes()).toEqual(0);
+        expect(m.toString()).toEqual("[[\"custom_field:host\",\"radware\"]]");
     }
 
     @Test


### PR DESCRIPTION
- HttpMessage: Drop host header (similar to `user-agent`, `content-type`, and `x-forwarded-for`)
- APIConnectMessage: Use host header to build `request_url` when possible (and fall back to gateway IP if not present, or actual host machine name if neither are present)