### PR TITLE
Fix/api connect host

### DIFF
--- a/src/main/java/io/resurface/ndjson/APIConnectMessage.java
+++ b/src/main/java/io/resurface/ndjson/APIConnectMessage.java
@@ -194,9 +194,14 @@ public class APIConnectMessage {
         if (msg.request_body() != null) requestBody = msg.request_body();
 
         // copy request headers
+        boolean hostHeaderExists = false;
         requestHttpHeaders = new ArrayList<>();
         if (msg.request_headers() != null) {
-            for (ArrayList<String> d : msg.request_headers()) requestHttpHeaders.add(Collections.singletonMap(d.get(0), d.get(1)));
+            for (ArrayList<String> d : msg.request_headers()) {
+                String key = d.get(0);
+                if (key.equalsIgnoreCase("host")) hostHeaderExists = true;
+                requestHttpHeaders.add(Collections.singletonMap(key, d.get(1)));
+            }
         }
         if (msg.request_content_type() != null) requestHttpHeaders.add(Collections.singletonMap("content-type", msg.request_content_type()));
         if (msg.request_user_agent() != null) requestHttpHeaders.add(Collections.singletonMap("user-agent", msg.request_user_agent()));
@@ -221,7 +226,7 @@ public class APIConnectMessage {
             try {
                 URL url = new URL(msg.request_url());
                 String urlHost = url.getHost();
-                if ((host == null || !host.equalsIgnoreCase(urlHost)) && (gatewayIp == null || !gatewayIp.equalsIgnoreCase(urlHost))) {
+                if ((!hostHeaderExists) && (host == null || !host.equalsIgnoreCase(urlHost)) && (gatewayIp == null || !gatewayIp.equalsIgnoreCase(urlHost))) {
                     requestHttpHeaders.add(Collections.singletonMap("host", urlHost));
                 }
                 requestProtocol = url.getProtocol();

--- a/src/main/java/io/resurface/ndjson/HttpMessage.java
+++ b/src/main/java/io/resurface/ndjson/HttpMessage.java
@@ -104,8 +104,6 @@ public class HttpMessage {
     public void add_request_header(String name, String value) {
         String name_lower = name.toLowerCase();
         switch (name_lower) {
-            case "host":
-                break; // dropped since 3.6
             case "content-type":
                 request_content_type = value;
                 break;

--- a/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
@@ -5,6 +5,7 @@ package io.resurface.ndjson.tests;
 import io.resurface.ndjson.APIConnectMessage;
 import io.resurface.ndjson.HttpMessage;
 import io.resurface.ndjson.HttpMessages;
+import io.resurface.ndjson.tests.Helper.*;
 import org.junit.Test;
 
 import static com.mscharhag.oleaster.matcher.Matchers.expect;
@@ -16,7 +17,7 @@ public class APIConnectMessageTest {
 
     @Test
     public void parseAndCopyTest() {
-        String[] Messages = Helper.APIConnect.getMessages();
+        String[] Messages = APIConnect.getMessages();
         for (String Message : Messages) {
             // parse dialect-specific JSON into HttpMessage
             HttpMessage m = HttpMessages.parse(Message, "ibm");
@@ -35,6 +36,246 @@ public class APIConnectMessageTest {
             HttpMessage m3 = HttpMessages.parse(a.toString(), "ibm");
             checkMessage(m3);
         }
+    }
+
+    @Test
+    public void parseAndCopyHostSourcesTest() {
+        HttpMessage m = HttpMessages.parse(APIConnect.DifferentHostSources, "ibm");
+        ExpectedHostFields expectedFields = new ExpectedHostFields(
+                "api.us-east-a.apiconnect.ibmappdomain.cloud",
+                "172.21.28.193",
+                "172.21.8.172"
+        );
+        checkShortMessage(m, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        APIConnectMessage a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        HttpMessage m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        HttpMessage m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.EqualHostSources, "ibm");
+        expectedFields = new ExpectedHostFields(
+                "192.168.0.123",
+                "192.168.0.123",
+                "192.168.0.123"
+        );
+        checkShortMessage(m,"192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "192.168.0.123", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.EqualSourcesDifferentHostHeader, "ibm");
+        expectedFields = new ExpectedHostFields(
+                "192.168.0.123:9443",
+                "192.168.0.123",
+                "192.168.0.123"
+        );
+        checkShortMessage(m, "192.168.0.123:9443", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "192.168.0.123:9443", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "192.168.0.123:9443", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.EqualSourcesNoHostHeader, "ibm");
+        expectedFields = new ExpectedHostFields(
+                null,
+                "192.168.0.123",
+                "192.168.0.123"
+        );
+        checkShortMessage(m, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "192.168.0.123", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.DifferentSourcesNoHostHeader, "ibm");
+        expectedFields = new ExpectedHostFields(
+                null,
+                "192.168.0.123",
+                "172.21.8.172"
+        );
+        checkShortMessage(m, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "192.168.0.123", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.OnlyMachineHostPresent, "ibm");
+        expectedFields = new ExpectedHostFields(
+                null,
+                null,
+                "172.21.8.172"
+        );
+        checkShortMessage(m, "172.21.8.172", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "172.21.8.172", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "172.21.8.172", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.OnlyGatewayIpPresent, "ibm");
+        expectedFields = new ExpectedHostFields(
+                null,
+                "192.168.0.123",
+                null
+        );
+        checkShortMessage(m, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "192.168.0.123", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "192.168.0.123", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+
+
+        m = HttpMessages.parse(APIConnect.OnlyHostHeaderPresent, "ibm");
+        expectedFields = new ExpectedHostFields(
+                "api.us-east-a.apiconnect.ibmappdomain.cloud",
+                null,
+                null
+        );
+        checkShortMessage(m, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        a = new APIConnectMessage(m);
+        checkShortMessage(a, expectedFields);
+
+        m2 = new HttpMessage();
+        a.copyTo(m2);
+        checkShortMessage(m2, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        m3 = HttpMessages.parse(a.toString(), "ibm");
+        checkShortMessage(m3, "api.us-east-a.apiconnect.ibmappdomain.cloud", expectedFields);
+
+        a = new APIConnectMessage();
+        a.copyFrom(m);
+        checkShortMessage(a, expectedFields);
+    }
+
+    private void checkShortMessage(HttpMessage m, String urlHost, ExpectedHostFields expected) {
+        final String formattedMessage = "[[\"request_header:accept\",\"*/*\"]%s,[\"request_url\",\"https://%s/myinstance/sandbox/get\"],[\"request_header:user-agent\",\"curl/8.4.0\"]%s%s]";
+        
+        String hostHeader = expected.hostHeader(); 
+        String machineHost = expected.machineHost();
+        String gatewayIp = expected.gatewayIp();
+                
+        m.sort_details();
+
+        expect(m.request_url()).toEqual(String.format("https://%s/myinstance/sandbox/get", urlHost));
+        expect(m.request_headers().size()).toEqual(1 + (hostHeader != null ? 1 : 0));
+        expect(m.request_headers().get(0).get(0)).toEqual("accept");
+        expect(m.request_headers().get(0).get(1)).toEqual("*/*");
+        if (hostHeader != null) {
+            expect(m.request_headers().get(1).get(0)).toEqual("host");
+            expect(m.request_headers().get(1).get(1)).toEqual(hostHeader);
+        }
+        expect(m.request_user_agent()).toEqual("curl/8.4.0");
+
+        expect(m.custom_fields().size()).toEqual((gatewayIp == null ? 0 : 1) + (machineHost == null ? 0 : 1));
+        if (gatewayIp != null) {
+            expect(m.custom_fields().get(0).get(0)).toEqual("gateway_ip");
+            expect(m.custom_fields().get(0).get(1)).toEqual(gatewayIp);
+        }
+        if (machineHost != null) {
+            expect(m.custom_fields().get(gatewayIp == null ? 0 : 1).get(0)).toEqual("host");
+            expect(m.custom_fields().get(gatewayIp == null ? 0 : 1).get(1)).toEqual(machineHost);
+        }
+
+        String hostHeaderDetail = hostHeader == null ? "" : String.format(",[\"request_header:host\",\"%s\"]", hostHeader);
+        String machineHostDetail = machineHost == null ? "" : String.format(",[\"custom_field:host\",\"%s\"]", machineHost);
+        String gatewayIpDetail = gatewayIp == null ? "" : String.format(",[\"custom_field:gateway_ip\",\"%s\"]", gatewayIp);
+
+        expect(m.toString()).toEqual(String.format(formattedMessage, hostHeaderDetail, urlHost, gatewayIpDetail, machineHostDetail));
+    }
+
+    private void checkShortMessage(APIConnectMessage m, ExpectedHostFields expected) {
+        String hostHeader = expected.hostHeader();
+        String machineHost = expected.machineHost();
+        String gatewayIp = expected.gatewayIp();
+
+        expect(m.host).toEqual(machineHost);
+
+        expect(m.requestProtocol).toEqual("https");
+        expect(m.uriPath).toEqual("/myinstance/sandbox/get");
+        expect(m.requestHttpHeaders.size()).toEqual(2 + (hostHeader == null ? 0 : 1));
+        expect(m.requestHttpHeaders.get(0).get("accept")).toEqual("*/*");
+        if (hostHeader != null) expect(m.requestHttpHeaders.get(1).get("host")).toEqual(hostHeader);
+        expect(m.requestHttpHeaders.get(1 + (hostHeader == null ? 0 : 1)).get("user-agent")).toEqual("curl/8.4.0");
+
+        expect(m.gatewayIp).toEqual(gatewayIp);
+
     }
 
     private void checkMessage(HttpMessage m) {

--- a/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/APIConnectMessageTest.java
@@ -58,13 +58,15 @@ public class APIConnectMessageTest {
 
         // check request headers
         expect(m.request_content_type()).toEqual("application/json");
-        expect(m.request_headers().size()).toEqual(3);
+        expect(m.request_headers().size()).toEqual(4);
         expect(m.request_headers().get(0).get(0)).toEqual("accept");
         expect(m.request_headers().get(0).get(1)).toEqual("*/*");
         expect(m.request_headers().get(1).get(0)).toEqual("content-length");
         expect(m.request_headers().get(1).get(1)).toEqual("30");
         expect(m.request_headers().get(2).get(0)).toEqual("foo");
         expect(m.request_headers().get(2).get(1)).toEqual("baz");
+        expect(m.request_headers().get(3).get(0)).toEqual("host");
+        expect(m.request_headers().get(3).get(1)).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud");
         expect(m.request_user_agent()).toEqual("curl/7.81.0");
 
         // check request method
@@ -125,9 +127,9 @@ public class APIConnectMessageTest {
         expect(m.requestHttpHeaders.get(0).get("accept")).toEqual("*/*");
         expect(m.requestHttpHeaders.get(1).get("content-length")).toEqual("30");
         expect(m.requestHttpHeaders.get(2).get("foo")).toEqual("baz");
-        expect(m.requestHttpHeaders.get(3).get("content-type")).toEqual("application/json");
-        expect(m.requestHttpHeaders.get(4).get("user-agent")).toEqual("curl/7.81.0");
-        expect(m.requestHttpHeaders.get(5).get("host")).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud");
+        expect(m.requestHttpHeaders.get(3).get("host")).toEqual("apis-minimum-gw-gateway-cp4i.b-vpc.us-south.containers.appdomain.cloud");
+        expect(m.requestHttpHeaders.get(4).get("content-type")).toEqual("application/json");
+        expect(m.requestHttpHeaders.get(5).get("user-agent")).toEqual("curl/7.81.0");
 
         // check request method
         expect(m.method).toEqual("POST");

--- a/src/test/java/io/resurface/ndjson/tests/Helper.java
+++ b/src/test/java/io/resurface/ndjson/tests/Helper.java
@@ -2,6 +2,7 @@ package io.resurface.ndjson.tests;
 
 public class Helper {
 
+    public record ExpectedHostFields(String hostHeader, String gatewayIp, String machineHost) {}
     public static class APIConnect {
 
         public static String[] getMessages() {
@@ -284,6 +285,111 @@ public class Helper {
             }
             
             """;
+
+        static final String DifferentHostSources = """
+                {
+                  "host":"172.21.8.172",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"host":"api.us-east-a.apiconnect.ibmappdomain.cloud"},
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "172.21.28.193"
+                }
+                """;
+
+        static final String EqualHostSources = """
+                {
+                  "host":"192.168.0.123",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"Host":"192.168.0.123"},
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "192.168.0.123"
+                }
+                """;
+
+        static final String EqualSourcesDifferentHostHeader = """
+                {
+                  "host":"192.168.0.123",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"Host":"192.168.0.123:9443"},
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "192.168.0.123"
+                }
+                """;
+
+        static final String EqualSourcesNoHostHeader = """
+                {
+                  "host":"192.168.0.123",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "192.168.0.123"
+                }
+                """;
+
+        static final String DifferentSourcesNoHostHeader = """
+                {
+                  "host":"172.21.8.172",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "192.168.0.123"
+                }
+                """;
+
+        static final String OnlyMachineHostPresent = """
+                {
+                  "host":"172.21.8.172",
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ]
+                }
+                """;
+
+        static final String OnlyGatewayIpPresent = """
+                {
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ],
+                  "gateway_ip": "192.168.0.123"
+                }
+                """;
+
+        static final String OnlyHostHeaderPresent = """
+                {
+                  "request_protocol": "https",
+                  "uri_path": "/myinstance/sandbox/get",
+                  "request_http_headers": [
+                    {"host":"api.us-east-a.apiconnect.ibmappdomain.cloud"},
+                    {"user-agent":"curl/8.4.0"},
+                    {"accept":"*/*"}
+                  ]
+                }
+                """;
+
     }
 
 }

--- a/src/test/java/io/resurface/ndjson/tests/HttpMessageTest.java
+++ b/src/test/java/io/resurface/ndjson/tests/HttpMessageTest.java
@@ -109,11 +109,13 @@ public class HttpMessageTest {
         expect(m.request_address()).toEqual("127.0.0.1");
         expect(m.request_body()).toEqual("{ \"hello\" : \"world\" }");
         expect(m.request_content_type()).toEqual("Application/JSON");
-        expect(m.request_headers().size()).toEqual(2);
+        expect(m.request_headers().size()).toEqual(3);
         expect(m.request_headers().get(0).get(0)).toEqual("a");
         expect(m.request_headers().get(0).get(1)).toEqual("2");
         expect(m.request_headers().get(1).get(0)).toEqual("b");
         expect(m.request_headers().get(1).get(1)).toEqual("1");
+        expect(m.request_headers().get(2).get(0)).toEqual("host");
+        expect(m.request_headers().get(2).get(1)).toEqual("test.pepperin.space");
         expect(m.request_method()).toEqual("POST");
         expect(m.request_params().size()).toEqual(2);
         expect(m.request_params().get(0).get(0)).toEqual("p1");


### PR DESCRIPTION
- `HttpMessage`: host header shouldn't be skipped/dropped (roll back one of yesterday's changes)
- `APIConnectMessageTest`: Add test cases for different host sources.